### PR TITLE
`--output` option fix

### DIFF
--- a/DBDump/BuildFile.xml
+++ b/DBDump/BuildFile.xml
@@ -7,10 +7,6 @@
 <use   name="CondFormats/EcalObjects"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CalibCalorimetry/EcalLaserCorrection"/>
-<use   name="py2-pybind11"/>
-<use   name="python3"/>
-
 <export>
-	  <use   name="py2-pybind11"/>
           <lib   name="1"/>
 </export>

--- a/DBDump/BuildFile.xml
+++ b/DBDump/BuildFile.xml
@@ -7,6 +7,10 @@
 <use   name="CondFormats/EcalObjects"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CalibCalorimetry/EcalLaserCorrection"/>
+<use   name="py2-pybind11"/>
+<use   name="python3"/>
+
 <export>
+	  <use   name="py2-pybind11"/>
           <lib   name="1"/>
 </export>

--- a/DBDump/bin/conddb_dumper.cpp
+++ b/DBDump/bin/conddb_dumper.cpp
@@ -29,8 +29,6 @@
 #include "CondFormats/ESObjects/interface/ESIntercalibConstants.h"
 #include "CondFormats/RunInfo/interface/RunInfo.h"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 int usage(char * s)
 {
@@ -274,16 +272,4 @@ int main(int argc, char** argv)
                 "Please check the spelling and, if correct, ask the experts for its implementation.\n", obj.c_str());
         list_supported(supported);
         return 2;
-}
-
-
-//---Python bindings
-namespace py = pybind11;
-
-// test
-PYBIND11_MODULE(conddb_dumper, m)
-{
-  m.def("usage",          &usage);
-    //.def("list_supported", &list_supported)
-    //.def("main",           &main);
 }

--- a/DBDump/bin/conddb_dumper.cpp
+++ b/DBDump/bin/conddb_dumper.cpp
@@ -29,6 +29,8 @@
 #include "CondFormats/ESObjects/interface/ESIntercalibConstants.h"
 #include "CondFormats/RunInfo/interface/RunInfo.h"
 
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 int usage(char * s)
 {
@@ -272,4 +274,16 @@ int main(int argc, char** argv)
                 "Please check the spelling and, if correct, ask the experts for its implementation.\n", obj.c_str());
         list_supported(supported);
         return 2;
+}
+
+
+//---Python bindings
+namespace py = pybind11;
+
+// test
+PYBIND11_MODULE(conddb_dumper, m)
+{
+  m.def("usage",          &usage);
+    //.def("list_supported", &list_supported)
+    //.def("main",           &main);
 }

--- a/DBDump/bin/conddb_dumper.cpp
+++ b/DBDump/bin/conddb_dumper.cpp
@@ -8,6 +8,7 @@
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
 #include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
 #include "CondFormats/EcalObjects/interface/EcalPedestals.h"
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/EcalObjects/interface/EcalPulseShapes.h"
@@ -89,6 +90,13 @@ int main(int argc, char** argv)
         supported.push_back("EcalLaserAlphas");
         if (!help && obj == "EcalLaserAlphas") {
                 cond::CondDBDumper<EcalLaserAlphas> d(obj);
+                d.run(argc, argv);
+                return 0;
+        }
+
+        supported.push_back("EcalLaserAPDPNRatios");
+        if (!help && obj == "EcalLaserAPDPNRatios") {
+                cond::CondDBDumper<EcalLaserAPDPNRatios> d(obj);
                 d.run(argc, argv);
                 return 0;
         }

--- a/DBDump/interface/CondDBDumper.h
+++ b/DBDump/interface/CondDBDumper.h
@@ -186,7 +186,10 @@ namespace cond {
                                         ++cnt;
                                         print(cnt_iov, i);
                                         std::shared_ptr<C> pa = session.fetchPayload<C>(i.payloadId);
-                                        if (!join) sprintf(filename, "dump_%s__since_%08llu_till_%08llu.dat", _class_name.c_str(), i.since, i.till);
+                                        if (!join) { 
+					  sprintf(filename, "dump_%s__since_%08llu_till_%08llu.dat", _class_name.c_str(), i.since, i.till);
+					  if (hasOptionValue("output")) sprintf(filename, "%s_%d.dat", _output_name(getOptionValue<std::string>("output").c_str()), cnt);
+					}
                                         fout = open_file(filename);
                                         if (join) fprintf(fout, "# new IOV: since %llu  till %llu\n", i.since, i.till);
                                         dump(fout, *pa);
@@ -525,6 +528,14 @@ namespace cond {
                 private:
                         std::string _class_name;
                         std::vector<DetId> _ids;
+			const char* _output_name (std::string opt_output_name)
+			{
+			  // if the output name was given with file extension, remove it
+			  size_t pos_ext = opt_output_name.find_last_of("."); 
+			  if (pos_ext != std::string::npos)  opt_output_name = opt_output_name.substr(0, pos_ext);
+			  return opt_output_name.c_str();
+			}
+
         };
 }
 

--- a/DBDump/interface/CondDBDumper.h
+++ b/DBDump/interface/CondDBDumper.h
@@ -528,13 +528,13 @@ namespace cond {
                 private:
                         std::string _class_name;
                         std::vector<DetId> _ids;
-			const char* _output_name (std::string opt_output_name)
-			{
-			  // if the output name was given with file extension, remove it
-			  size_t pos_ext = opt_output_name.find_last_of("."); 
-			  if (pos_ext != std::string::npos)  opt_output_name = opt_output_name.substr(0, pos_ext);
-			  return opt_output_name.c_str();
-			}
+                        const char* _output_name (std::string opt_output_name)
+                        {
+                          // if the output name was given with file extension, remove it
+                          size_t pos_ext = opt_output_name.find_last_of(".");
+                          if (pos_ext != std::string::npos)  opt_output_name = opt_output_name.substr(0, pos_ext);
+                          return opt_output_name.c_str();
+                        }
 
         };
 }

--- a/DBDump/interface/CondDBDumper.h
+++ b/DBDump/interface/CondDBDumper.h
@@ -186,7 +186,7 @@ namespace cond {
                                         ++cnt;
                                         print(cnt_iov, i);
                                         std::shared_ptr<C> pa = session.fetchPayload<C>(i.payloadId);
-                                        if (!join) { 
+                                        if (!join) {
 					  sprintf(filename, "dump_%s__since_%08llu_till_%08llu.dat", _class_name.c_str(), i.since, i.till);
 					  if (hasOptionValue("output")) sprintf(filename, "%s_%d.dat", _output_name(getOptionValue<std::string>("output").c_str()), cnt);
                                         }

--- a/DBDump/interface/CondDBDumper.h
+++ b/DBDump/interface/CondDBDumper.h
@@ -189,7 +189,7 @@ namespace cond {
                                         if (!join) { 
 					  sprintf(filename, "dump_%s__since_%08llu_till_%08llu.dat", _class_name.c_str(), i.since, i.till);
 					  if (hasOptionValue("output")) sprintf(filename, "%s_%d.dat", _output_name(getOptionValue<std::string>("output").c_str()), cnt);
-					}
+                                        }
                                         fout = open_file(filename);
                                         if (join) fprintf(fout, "# new IOV: since %llu  till %llu\n", i.since, i.till);
                                         dump(fout, *pa);

--- a/DBDump/interface/CondDBDumper.h
+++ b/DBDump/interface/CondDBDumper.h
@@ -47,7 +47,6 @@ namespace cond {
         class CondDBDumper : public cond::Utilities {
 
                 public:
-
                         CondDBDumper(std::string class_name) : Utilities("conddb_dumper"), _class_name(class_name)
                         {
                                 addAuthenticationOptions();
@@ -93,7 +92,7 @@ namespace cond {
                         {
                         }
 
-
+                
                         void print(int cnt, const cond::Iov_t & iov)
                         {
                                 printf("%d  %llu %llu\n", cnt, iov.since, iov.till);
@@ -198,12 +197,13 @@ namespace cond {
                                         ++cnt;
                                         print(cnt_iov, i);
                                         std::shared_ptr<C> pa = session.fetchPayload<C>(i.payloadId);
-					
-					if (!range) 
-					  if (!join) {
-					    sprintf(filename, "dump_%s__%ssince_%08llu_till_%08llu.dat", _class_name.c_str(), snow.c_str(), i.since, i.till);
-					    if (hasOptionValue("output")) sprintf(filename, "%s_%d.dat", _output_name(getOptionValue<std::string>("output").c_str()), cnt);
-					  }
+                                        
+                                        if (!range) {
+                                                if (!join) {
+                                                        sprintf(filename, "dump_%s__%ssince_%08llu_till_%08llu.dat", _class_name.c_str(), snow.c_str(), i.since, i.till);
+                                                        if (hasOptionValue("output")) sprintf(filename, "%s_%d.dat", _output_name(getOptionValue<std::string>("output").c_str()), cnt);
+                                                }
+                                        }
                                         fout = open_file(filename);
                                         if (join) fprintf(fout, "# new IOV: since %llu  till %llu\n", i.since, i.till);
                                         dump(fout, *pa);
@@ -560,8 +560,8 @@ namespace cond {
 
                         void dump(FILE * fd, BeamSpotObjects & bs)
                         {
-//                                fprintf(fd, "z= %f  z_err= %f  sigma_z= %f sigma_z_err= %f\n",
-//                                        bs.z(), bs.zError(), bs.sigmaZ(), bs.sigmaZError());
+                                fprintf(fd, "z= %f  z_err= %f  sigma_z= %f sigma_z_err= %f\n",
+                                        bs.z(), bs.zError(), bs.sigmaZ(), bs.sigmaZError());
                         }
 
 
@@ -570,10 +570,10 @@ namespace cond {
                         std::vector<DetId> _ids;
                         const char* _output_name (std::string opt_output_name)
                         {
-                          // if the output name was given with file extension, remove it
-                          size_t pos_ext = opt_output_name.find_last_of(".");
-                          if (pos_ext != std::string::npos)  opt_output_name = opt_output_name.substr(0, pos_ext);
-                          return opt_output_name.c_str();
+                                // if the output name was given with file extension, remove it
+                                size_t pos_ext = opt_output_name.find_last_of(".");
+                                if (pos_ext != std::string::npos)  opt_output_name = opt_output_name.substr(0, pos_ext);
+                                return opt_output_name.c_str();
                         }
 
         };

--- a/DBDump/interface/CondDBDumper.h
+++ b/DBDump/interface/CondDBDumper.h
@@ -421,18 +421,6 @@ namespace cond {
                                 }
                         }
 
-                        void dump(FILE * fd, EcalLaserAPDPNRatios & o)
-                        {
-                            for (size_t i = 0; i < _ids.size(); ++i) {
-                                DetId id(_ids[i]);
-                                auto it = o.getLaserMap().find(id);
-                                coord(_ids[i]);                                
-                                fprintf(fd, "%d %d %d %f %f %f %d\n", _c.ix_, _c.iy_, _c.iz_, 
-                                        (*it).p1, (*it).p2, (*it).p3,
-                                        id.rawId());                                
-                            }
-                        }
-
                         void dump(FILE * fd, EcalSimPulseShape & o)
                         {
                                 fprintf(fd, "# TI=%f EB_THR=%f  EE_THR=%f APD_THR=%f\n", o.time_interval, o.barrel_thresh, o.endcap_thresh, o.apd_thresh);

--- a/DBDump/interface/CondDBDumper.h
+++ b/DBDump/interface/CondDBDumper.h
@@ -16,6 +16,7 @@
 #include "CondFormats/EcalObjects/interface/EcalClusterLocalContCorrParameters.h"
 #include "CondFormats/EcalObjects/interface/EcalCondObjectContainer.h"
 #include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
 #include "CondFormats/EcalObjects/interface/EcalPedestals.h"
 #include "CondFormats/EcalObjects/interface/EcalPulseShapes.h"
 #include "CondFormats/EcalObjects/interface/EcalPulseCovariances.h"
@@ -392,6 +393,18 @@ namespace cond {
                                                 (*it).gain12Over6(), (*it).gain6Over1(),
                                                 id.rawId());
                                 }
+                        }
+
+                        void dump(FILE * fd, EcalLaserAPDPNRatios & o)
+                        {
+                            for (size_t i = 0; i < _ids.size(); ++i) {
+                                DetId id(_ids[i]);
+                                auto it = o.getLaserMap().find(id);
+                                coord(_ids[i]);                                
+                                fprintf(fd, "%d %d %d %f %f %f %d\n", _c.ix_, _c.iy_, _c.iz_, 
+                                        (*it).p1, (*it).p2, (*it).p3,
+                                        id.rawId());                                
+                            }
                         }
 
                         void dump(FILE * fd, EcalSimPulseShape & o)

--- a/DBDump/interface/CondDBDumper.h
+++ b/DBDump/interface/CondDBDumper.h
@@ -533,8 +533,8 @@ namespace cond {
 
                         void dump(FILE * fd, BeamSpotObjects & bs)
                         {
-                                fprintf(fd, "z= %f  z_err= %f  sigma_z= %f sigma_z_err= %f\n",
-                                        bs.z(), bs.zError(), bs.sigmaZ(), bs.sigmaZError());
+//                                fprintf(fd, "z= %f  z_err= %f  sigma_z= %f sigma_z_err= %f\n",
+//                                        bs.z(), bs.zError(), bs.sigmaZ(), bs.sigmaZError());
                         }
 
 


### PR DESCRIPTION
Allow `--output` option in `(! join)` dumps to be used.
Produces `<output>_<cnt>.dat` files, where `cnt` is the count of iovs selected. 
`_output_name` is a safety check to avoid repeated `.dat` strings.